### PR TITLE
Removed none-used apcu-adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "cache/apcu-adapter": "1.0.0",
         "firebase/php-jwt": "5.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
There was a conflict between cache/apcu-adapter with cache/cache when using cybersource-rest-client-php with magento-ce-2.3.5. 

Error: "cache/apcu-adapter 1.0.0 conflicts with cache/cache"

Take a deeper look at cybersource-rest-client-php you don't really use ApcuCachePool, but I do see you are using apcu_fetch and apcu_store which are already provided by PHP7. So we don't really need cache/apcu-adapter and it is safe to remove.