### PR TITLE
Use caret version range for dependency cache/apcu-adapter.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "cache/apcu-adapter": "1.0.0",
+        "cache/apcu-adapter": "^1.0.0",
         "firebase/php-jwt": "^5.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Allows composer to install [cache/apcu-adapter](https://packagist.org/packages/cache/apcu-adapter) version greater than `1.0.0`. This allows install on a PHP8 platform as it can use `cache/apcu-adapter` version `1.1.0` which declares PHP8 compatibility.

Related to #47.