### PR TITLE
Remove require_once statement JsonWebTokenHeader

### DIFF
--- a/lib/Authentication/Jwt/JsonWebTokenHeader.php
+++ b/lib/Authentication/Jwt/JsonWebTokenHeader.php
@@ -9,8 +9,6 @@ use CyberSource\Authentication\Core\AuthException as AuthException;
 use Firebase\JWT\JWT as JWT;
 use CyberSource\Logging\LogFactory as LogFactory;
 
-require_once 'vendor/autoload.php';
-
 class JsonWebTokenHeader 
 {
     private static $logger = null;


### PR DESCRIPTION
The composer autoloader should be required by the application code, not the library itself.

This causes a fatal error because there is no `vendor/autoload.php` file in lib/Jwt directory where the JsonWebTokenHeader.php file is located.