### PR TITLE
Upgrade firebase/php-jwt v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "cache/apcu-adapter": "1.1.0",
-        "firebase/php-jwt": "^5.0.0",
-		"monolog/monolog": ">=1.25.0"
+        "firebase/php-jwt": "^6.0.0",
+        "monolog/monolog": ">=1.25.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8"


### PR DESCRIPTION
Should fix https://github.com/CyberSource/cybersource-rest-client-php/issues/119

Upgrading firebase/php-jwt to v6 because v5 is vulnerable https://github.com/advisories/GHSA-8xf4-w7qw-pjjw 

Here are the Backwards Compatibility Breaking Changes : https://github.com/firebase/php-jwt/releases/tag/v6.0.0

The cybersource SDK itself isn't vulnerable because you are providing the `$alg` param when calling `JWT::encode()`, but it forces the version 5 on the whole project, and that may be a security problem for project depending on your lib.


I didnt manage to run phpunit tests on my local env, do you have any CI configured somewhere ?