### PR TITLE
Add configurable TLS version and cipher suite support

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -349,6 +349,19 @@ class ApiClient
             curl_setopt($curl, CURLOPT_PROXYUSERPWD, $this->config->getCurlProxyUser() . ':' .$this->config->getCurlProxyPassword());
         }
 
+        if ($this->config->getTlsVersion()) {
+            curl_setopt($curl, CURLOPT_SSLVERSION, $this->config->getTlsVersion());
+        }
+
+        if ($this->config->getTlsCipherList()) {
+            // use TLS 1.3 ciphers for TLS 1.3, otherwise use general SSL cipher list
+            if ($this->config->getTlsVersion() && $this->config->getTlsVersion() === CURL_SSLVERSION_TLSv1_3) {
+                curl_setopt($curl, CURLOPT_TLS13_CIPHERS, $this->config->getTlsCipherList());
+            } else {
+                curl_setopt($curl, CURLOPT_SSL_CIPHER_LIST, $this->config->getTlsCipherList());
+            }
+        }
+
         if (!empty($queryParams)) {
             $url = ($url . '?' . http_build_query($queryParams));
         }

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -174,6 +174,20 @@ class Configuration
     protected $allowEncoding = false;
 
     /**
+     * TLS version to use for HTTPS requests
+     *
+     * @var string
+     */
+    protected $tlsVersion;
+
+    /**
+     * TLS cipher list to use for HTTPS requests
+     *
+     * @var string
+     */
+    protected $tlsCipherList;
+
+    /**
      * Logging configuration
      *
      * @var LogConfiguration
@@ -570,6 +584,53 @@ class Configuration
     public function getLogConfiguration()
     {
         return $this->logConfig;
+    }
+
+
+    /**
+     * Sets the TLS version to use for HTTPS requests
+     *
+     * @param string $tlsVersion TLS version (e.g. CURL_SSLVERSION_TLSv1_2)
+     *
+     * @return $this
+     */
+    public function setTlsVersion($tlsVersion)
+    {
+        $this->tlsVersion = $tlsVersion;
+        return $this;
+    }
+
+    /**
+     * Gets the TLS version to use for HTTPS requests
+     *
+     * @return string TLS version
+     */
+    public function getTlsVersion()
+    {
+        return $this->tlsVersion;
+    }
+
+    /**
+     * Sets the TLS cipher list to use for HTTPS requests
+     *
+     * @param string $tlsCipherList TLS cipher list
+     *
+     * @return $this
+     */
+    public function setTlsCipherList($tlsCipherList)
+    {
+        $this->tlsCipherList = $tlsCipherList;
+        return $this;
+    }
+
+    /**
+     * Gets the TLS cipher list to use for HTTPS requests
+     *
+     * @return string TLS cipher list
+     */
+    public function getTlsCipherList()
+    {
+        return $this->tlsCipherList;
     }
 
     /**


### PR DESCRIPTION
##  Summary

  This PR adds configurable TLS version and cipher suite support, allowing users to specify custom TLS settings for security
  compliance.

 ## Why this is needed

  Many enterprise environments require specific TLS versions (e.g., TLS 1.3 only) and custom cipher suites to meet compliance requirements or security policies. 
 Currently, the SDK uses default curl TLS settings, which may not meet these stricter security standards.

  ## Changes

  - Added setTlsVersion() and getTlsVersion() methods to Configuration class
  - Added setTlsCipherList() and getTlsCipherList() methods to Configuration class
  - Enhanced ApiClient to automatically apply TLS settings using appropriate curl options (CURLOPT_TLS13_CIPHERS for TLS 1.3, CURLOPT_SSL_CIPHER_LIST for older versions)
  - Maintains full backward compatibility with existing SSL configuration

  This enables users to enforce specific TLS security requirements while maintaining the existing API structure.
