### PR TITLE
Add JWT shared secret signing

### DIFF
--- a/lib/Authentication/Core/MerchantConfiguration.php
+++ b/lib/Authentication/Core/MerchantConfiguration.php
@@ -24,6 +24,25 @@ class MerchantConfiguration
     protected $authenticationType = '';
 
     /**
+     * Signing method when authenticationType is JWT.
+     *
+     * Either GlobalParameter::JWT_SIGNING_P12 (default) for X.509 / RS256 signing using a P12
+     * certificate, or GlobalParameter::JWT_SIGNING_SHARED_SECRET for HMAC signing using a
+     * shared-secret key pair generated in the CyberSource Business Center.
+     *
+     * @var string
+     */
+    protected $jwtSigningMethod = GlobalParameter::JWT_SIGNING_P12;
+
+    /**
+     * HMAC algorithm used when jwtSigningMethod is SHARED_SECRET. Supported values are
+     * HS256, HS384, and HS512. Defaults to HS256.
+     *
+     * @var string
+     */
+    protected $jwtSharedSecretAlgorithm = GlobalParameter::HS256;
+
+    /**
      * merchantID for HTTP basic authentication
      *
      * @var string
@@ -378,6 +397,55 @@ class MerchantConfiguration
     public function getAuthenticationType()
     {
         return $this->authenticationType;
+    }
+
+    /**
+     * Sets the JWT signing method.
+     *
+     * Accepts GlobalParameter::JWT_SIGNING_P12 (default, RS256 via P12 certificate) or
+     * GlobalParameter::JWT_SIGNING_SHARED_SECRET (HMAC via shared secret key pair).
+     *
+     * @param string $jwtSigningMethod
+     *
+     * @return $this
+     */
+    public function setJwtSigningMethod($jwtSigningMethod)
+    {
+        $this->jwtSigningMethod = strtoupper(trim((string) $jwtSigningMethod));
+        return $this;
+    }
+
+    /**
+     * Gets the JWT signing method. Defaults to P12 for backward compatibility.
+     *
+     * @return string
+     */
+    public function getJwtSigningMethod()
+    {
+        return $this->jwtSigningMethod;
+    }
+
+    /**
+     * Sets the HMAC algorithm used when signing with a shared secret.
+     *
+     * @param string $algorithm One of HS256, HS384, HS512.
+     *
+     * @return $this
+     */
+    public function setJwtSharedSecretAlgorithm($algorithm)
+    {
+        $this->jwtSharedSecretAlgorithm = strtoupper(trim((string) $algorithm));
+        return $this;
+    }
+
+    /**
+     * Gets the HMAC algorithm used when signing with a shared secret.
+     *
+     * @return string
+     */
+    public function getJwtSharedSecretAlgorithm()
+    {
+        return $this->jwtSharedSecretAlgorithm;
     }
 
     /**
@@ -1398,6 +1466,12 @@ class MerchantConfiguration
         else
             $error_message .= GlobalParameter::AUTHTYPE;
 
+        if(isset($connectionDet->jwtSigningMethod))
+            $config = $config->setJwtSigningMethod($connectionDet->jwtSigningMethod);
+
+        if(isset($connectionDet->jwtSharedSecretAlgorithm))
+            $config = $config->setJwtSharedSecretAlgorithm($connectionDet->jwtSharedSecretAlgorithm);
+
         if(isset($connectionDet->merchantID))
             $config = $config->setMerchantID($connectionDet->merchantID);
         else
@@ -1595,35 +1669,56 @@ class MerchantConfiguration
             $error_message .= GlobalParameter::MERCHANTID_REQ . PHP_EOL;
         }
 
-        if(empty($this->getKeyAlias()) && $this->getAuthenticationType() == GlobalParameter::JWT){
-            $warning_message .= GlobalParameter::KEY_ALIAS_NULL_EMPTY . PHP_EOL;
-        }
+        if($this->getAuthenticationType() == GlobalParameter::JWT){
+            $signingMethod = $this->getJwtSigningMethod();
 
-        // Only enforce KeyAlias = MerchantId when UseMetaKey is false
-        if($this->getAuthenticationType() == GlobalParameter::JWT && !$this->getUseMetaKey()){
-            if(!empty($this->getKeyAlias()) && ($this->getKeyAlias() != $this->getMerchantID())){
-                $this->setKeyAlias($this->getMerchantID());
-                $warning_message .= GlobalParameter::KEY_ALIAS_INCORRECT . PHP_EOL;
+            if($signingMethod === GlobalParameter::JWT_SIGNING_SHARED_SECRET){
+
+                if(empty($this->getApiKeyID())){
+                    $error_message .= GlobalParameter::JWT_SHARED_SECRET_KEY_ID_REQ;
+                }
+
+                if(empty($this->getSecretKey())){
+                    $error_message .= GlobalParameter::JWT_SHARED_SECRET_KEY_REQ;
+                }
+
+                if(!in_array($this->getJwtSharedSecretAlgorithm(), GlobalParameter::SUPPORTED_JWT_SHARED_SECRET_ALGS, true)){
+                    $error_message .= GlobalParameter::JWT_SHARED_SECRET_INVALID_ALG;
+                }
+
+            } else {
+
+                if(empty($this->getKeyAlias())){
+                    $warning_message .= GlobalParameter::KEY_ALIAS_NULL_EMPTY . PHP_EOL;
+                }
+
+                // Only enforce KeyAlias = MerchantId when UseMetaKey is false
+                if(!$this->getUseMetaKey()){
+                    if(!empty($this->getKeyAlias()) && ($this->getKeyAlias() != $this->getMerchantID())){
+                        $this->setKeyAlias($this->getMerchantID());
+                        $warning_message .= GlobalParameter::KEY_ALIAS_INCORRECT . PHP_EOL;
+                    }
+                }
+
+                if($this->getUseMetaKey()){
+                    if(!empty($this->getKeyAlias()) && ($this->getKeyAlias() != $this->getPortfolioID())){
+                        $this->setKeyAlias($this->getPortfolioID());
+                        $warning_message .= GlobalParameter::INCORRECT_KEY_ALIAS_FOR_METAKEY . PHP_EOL;
+                    }
+                }
+
+                if(empty($this->getKeyFileName())){
+                    $warning_message .= GlobalParameter::KEY_FILE_NULL_EMPTY . PHP_EOL;
+                }
+
+                if(empty($this->getKeyPassword())){
+                    $error_message .= GlobalParameter::KEY_PASSWORD_EMPTY . PHP_EOL;
+                }
+
+                if(empty($this->getKeysDirectory())){
+                    $warning_message .= GlobalParameter::KEY_DIRECTORY_EMPTY . PHP_EOL;
+                }
             }
-        }
-
-        if($this->getAuthenticationType() == GlobalParameter::JWT && $this->getUseMetaKey()){
-            if(!empty($this->getKeyAlias()) && ($this->getKeyAlias() != $this->getPortfolioID())){
-                $this->setKeyAlias($this->getPortfolioID());
-                $warning_message .= GlobalParameter::INCORRECT_KEY_ALIAS_FOR_METAKEY . PHP_EOL;
-            }
-        }
-
-        if(empty($this->getKeyFileName()) && $this->getAuthenticationType() == GlobalParameter::JWT){
-            $warning_message .= GlobalParameter::KEY_FILE_NULL_EMPTY . PHP_EOL;
-        }
-
-        if(empty($this->getKeyPassword()) && $this->getAuthenticationType() == GlobalParameter::JWT){
-            $error_message .= GlobalParameter::KEY_PASSWORD_EMPTY . PHP_EOL;
-        }
-        
-        if(empty($this->getKeysDirectory()) && $this->getAuthenticationType() == GlobalParameter::JWT){
-            $warning_message .= GlobalParameter::KEY_DIRECTORY_EMPTY . PHP_EOL;
         }
 
         if(empty($this->getMerchantID()) && $this->getAuthenticationType() == GlobalParameter::HTTP_SIGNATURE){

--- a/lib/Authentication/Jwt/JsonWebTokenGenerator.php
+++ b/lib/Authentication/Jwt/JsonWebTokenGenerator.php
@@ -120,7 +120,7 @@ class JsonWebTokenGenerator implements TokenGenerator
         // Set the request method, host and resource path in the JWT body as per the specification for all request types
         $jwtPayload["request-method"] = strtoupper($method);
         $jwtPayload["request-host"] = $merchantConfig->getRunEnvironment();
-        $jwtPayload["request-resource-path"] = $this->extractResourcePath($resourcePath);
+        $jwtPayload["request-resource-path"] = $this->extractResourcePath($resourcePath, $method);
 
         // Choose issuer claim in the JWT body as per the use_metakey flag in the config file
         if($merchantConfig->getUseMetaKey())
@@ -176,13 +176,22 @@ class JsonWebTokenGenerator implements TokenGenerator
         }
     }
 
-    private function extractResourcePath($resourcePath)
+    private function extractResourcePath($resourcePath, $method = null)
     {
         if (empty($resourcePath)) {
             return "";
         }
 
-        // Split the string to remove the query params
+        // GET and DELETE requests have no body to digest, so the query string is the only
+        // request-specific data covered by the JWT signature. Include it in the signed path
+        // to match the HTTP Signature scheme's request-target behavior.
+        $upperMethod = strtoupper((string) $method);
+        if ($upperMethod === GlobalParameter::GET || $upperMethod === GlobalParameter::DELETE) {
+            return $resourcePath;
+        }
+
+        // For body-bearing methods (POST/PUT/PATCH), the body's digest claim covers any
+        // request-specific data, so the path is signed without the query string.
         $parts = explode('?', $resourcePath, 2);
         return $parts[0];
     }

--- a/lib/Authentication/Jwt/JsonWebTokenGenerator.php
+++ b/lib/Authentication/Jwt/JsonWebTokenGenerator.php
@@ -36,6 +36,19 @@ class JsonWebTokenGenerator implements TokenGenerator
     {
         $jwtPayload = $this->getPayloadClaimSet($resourcePath, $payloadData, $method, $merchantConfig, $isResponseMLEForAPI);
         $headerClaimSet = $this->getHeaderClaimSet();
+
+        if ($merchantConfig->getJwtSigningMethod() === GlobalParameter::JWT_SIGNING_SHARED_SECRET) {
+            $generatedToken = $this->signWithSharedSecret($jwtPayload, $headerClaimSet, $merchantConfig);
+        } else {
+            $generatedToken = $this->signWithP12Certificate($jwtPayload, $headerClaimSet, $merchantConfig);
+        }
+
+        self::$logger->close();
+        return "Bearer ".$generatedToken;
+    }
+
+    private function signWithP12Certificate($jwtPayload, $headerClaimSet, $merchantConfig)
+    {
         try {
             $cacheData = self::$cache->grabFileFromP12($merchantConfig);
         } catch (AuthException $e) {
@@ -52,9 +65,38 @@ class JsonWebTokenGenerator implements TokenGenerator
         }
 
         $kid = strval($this->extractSerialNumber($x509Certificate));
-        $generatedToken = JWT::encode($jwtPayload, $privateKey, GlobalParameter::RS256, $kid, $headerClaimSet);
-        self::$logger->close();
-        return "Bearer ".$generatedToken;
+        return JWT::encode($jwtPayload, $privateKey, GlobalParameter::RS256, $kid, $headerClaimSet);
+    }
+
+    private function signWithSharedSecret($jwtPayload, $headerClaimSet, $merchantConfig)
+    {
+        $algorithm = $merchantConfig->getJwtSharedSecretAlgorithm();
+        if (!in_array($algorithm, GlobalParameter::SUPPORTED_JWT_SHARED_SECRET_ALGS, true)) {
+            self::$logger->error("AuthException: " . GlobalParameter::JWT_SHARED_SECRET_INVALID_ALG);
+            throw new AuthException("AuthException: " . GlobalParameter::JWT_SHARED_SECRET_INVALID_ALG);
+        }
+
+        $kid = $merchantConfig->getApiKeyID();
+        if (empty($kid)) {
+            self::$logger->error("AuthException: " . GlobalParameter::JWT_SHARED_SECRET_KEY_ID_REQ);
+            throw new AuthException("AuthException: " . GlobalParameter::JWT_SHARED_SECRET_KEY_ID_REQ);
+        }
+
+        // The shared secret value is base64-encoded in the Business Center; decode it before
+        // using it as an HMAC key, per CyberSource JWT shared-secret guidance.
+        $rawSecret = $merchantConfig->getSecretKey();
+        if (empty($rawSecret)) {
+            self::$logger->error("AuthException: " . GlobalParameter::JWT_SHARED_SECRET_KEY_REQ);
+            throw new AuthException("AuthException: " . GlobalParameter::JWT_SHARED_SECRET_KEY_REQ);
+        }
+
+        $decodedSecret = base64_decode($rawSecret, true);
+        if ($decodedSecret === false) {
+            self::$logger->error(GlobalParameter::JWT_SHARED_SECRET_DECODE_FAIL);
+            throw new AuthException(GlobalParameter::JWT_SHARED_SECRET_DECODE_FAIL);
+        }
+
+        return JWT::encode($jwtPayload, $decodedSecret, $algorithm, $kid, $headerClaimSet);
     }
 
     private function getPayloadClaimSet($resourcePath, $payloadData, $method, $merchantConfig, $isResponseMLEForAPI)

--- a/lib/Authentication/Util/GlobalParameter.php
+++ b/lib/Authentication/Util/GlobalParameter.php
@@ -36,6 +36,12 @@ class GlobalParameter
     const POSTALGOHEADER = "host date request-target digest v-c-merchant-id";
     const GETALGOHEADER = "host date request-target v-c-merchant-id";
     const RS256 = "RS256";
+    const HS256 = "HS256";
+    const HS384 = "HS384";
+    const HS512 = "HS512";
+    const JWT_SIGNING_P12 = "P12";
+    const JWT_SIGNING_SHARED_SECRET = "SHARED_SECRET";
+    const SUPPORTED_JWT_SHARED_SECRET_ALGS = ["HS256", "HS384", "HS512"];
     const FILE_NOT_FOUND = "[ERROR] : File not found, Re-Enter path/file name, Entered path/file name : ";
     const MISSING_REQUEST = "[ERROR] : Request Not Found.";
     const MERCHANTCONFIGERR = "[ERROR] : Merchant Configuration Object is empty!";
@@ -113,5 +119,10 @@ class GlobalParameter
     const REQUEST_MLE_AUTH_ERROR = "Request MLE is only supported in JWT auth type";
     const EMPTY_PRIVATE_OR_PUBLIC_KEY_ERROR = "Private key or public key is empty";
     const PUBLIC_KEY_CACHE_IDENTIFIER = "FlexV2PublicKeys";
+    const JWT_SHARED_SECRET_INVALID_ALG = "Invalid jwtSharedSecretAlgorithm. Supported values are: HS256, HS384, HS512.\n";
+    const JWT_SHARED_SECRET_KEY_ID_REQ = "Merchant ApikeyId is mandatory for JWT shared secret signing\n";
+    const JWT_SHARED_SECRET_KEY_REQ = "MerchantSecretKey is mandatory for JWT shared secret signing\n";
+    const JWT_SHARED_SECRET_DECODE_FAIL = "[ERROR] : Unable to base64 decode the merchantsecretKey value.\n";
+    const REQUEST_MLE_SHARED_SECRET_NOT_SUPPORTED = "Request MLE is not supported when jwtSigningMethod is SHARED_SECRET.";
 }
 ?>


### PR DESCRIPTION
# Summary

This PR adds support for [JWT shared secret authentication](https://developer.cybersource.com/docs/cybs/en-us/platform/developer/all/rest/rest-getting-started/restgs-jwt-shared-secret-intro.html).

My team and I have been updating our integration to migrate from HTTP signature messaging to JWT using a shared secret key pair. It looks like the SDK only supported JWT using a P12 certificate, so this PR adds support for shared secret as an alternative.

The default signing method is set to P12 so existing JWT users get no behaviour changes.

We're hoping to be able to use these changes in our project before the September 2026 deadline, so a review of this PR would be hugely appreciated!

## Example usage

The new path is opt-in via two new config fields: `jwtSigningMethod` (set to `SHARED_SECRET`) and `jwtSharedSecretAlgorithm` (one of `HS256`, `HS384`, `HS512` — defaults to `HS256`). When `jwtSigningMethod` is unset or set to `P12`, the existing P12 certificate flow runs unchanged.

### Via `cybs.json`

```json
{
    "authenticationType":         "JWT",
    "jwtSigningMethod":           "SHARED_SECRET",
    "jwtSharedSecretAlgorithm":   "HS256",
    "merchantID":                 "your_merchant_id",
    "merchantKeyId":              "08c94330-f618-42a3-b09d-e1e43be5efda",
    "merchantsecretKey":          "yBJxy6LjM2TmcPGu+GaJrHtkke25fPpUX+UY6/L/1tE=",
    "runEnvironment":             "apitest.cybersource.com",
    "enableLog":                  true
}
```

### Programmatic

```php
use CyberSource\Authentication\Core\MerchantConfiguration;
use CyberSource\Authentication\Util\GlobalParameter;

$config = new MerchantConfiguration();

$config->setAuthenticationType(GlobalParameter::JWT);
$config->setJwtSigningMethod(GlobalParameter::JWT_SIGNING_SHARED_SECRET);
$config->setJwtSharedSecretAlgorithm(GlobalParameter::HS256);

$config->setMerchantID('your_merchant_id');
$config->setApiKeyID('08c94330-f618-42a3-b09d-e1e43be5efda');     // shared secret key ID
$config->setSecretKey('yBJxy6LjM2TmcPGu+GaJrHtkke25fPpUX+UY6/L/1tE='); // shared secret value
$config->setRunEnvironment('apitest.cybersource.com');

// Existing P12 fields (keysDirectory, keyFilename, keyPass, keyAlias) are not used and
// not required when signing with a shared secret.
```

## `extractResourcePath()` changes

`extractResourcePath()` previously stripped the query string from the resource path unconditionally before placing it in the `request-resource-path` claim. This works for body-bearing methods (POST/PUT/PATCH) since the request body is hashed into the `digest` claim — the signature already covers request-specific data.

GETs and DELETEs have no body and no `digest` claim, so the query string is the only request-specific data the signature can cover. Stripping it caused reporting endpoints (`GET /reporting/v3/conversion-details?...`) to return `401 Unauthorized` while the same request under HTTP Signature succeeded.

`extractResourcePath()` now takes the HTTP method as a second argument. For GET and DELETE it returns the resource path verbatim; for everything else it strips the query string as before, preserving prior behavior.

### Reproduction steps

```php
<?php

require __DIR__ . '/vendor/autoload.php';

use CyberSource\Api\ConversionDetailsApi;
use CyberSource\ApiClient;
use CyberSource\Configuration;
use CyberSource\Authentication\Core\MerchantConfiguration;
use CyberSource\Authentication\Util\GlobalParameter;

$mc = new MerchantConfiguration();
$mc->setRunEnvironment('apitest.cybersource.com');
$mc->setMerchantID('your_merchant_id');
$mc->setKeyAlias('your_merchant_id');
$mc->setKeyFileName('your_merchant_id');
$mc->setKeyPassword('your_p12_password');
$mc->setKeysDirectory(__DIR__ . '/Resources/');
$mc->setAuthenticationType(GlobalParameter::JWT);

$client = new ApiClient((new Configuration())->setHost($mc->getRunEnvironment()), $mc);
$api    = new ConversionDetailsApi($client);

// Returns 401 Unauthorized before the fix
$api->getConversionDetail(new DateTime('-2 hours'), new DateTime('now'), 'your_merchant_id');
```